### PR TITLE
Issue 001 test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 # Profiling
 if(MY_PROFILING)
+    message(STATUS "Enabling profiling and coverage.")
     list(APPEND flags -fprofile-arcs -ftest-coverage)
 endif()
 
@@ -75,13 +76,6 @@ target_compile_options(spa
     ${flags}
   )
 
-# really only needed for debug coverage
-if(MY_PROFILING)
-    target_link_libraries(spa "--coverage")
-    target_link_libraries(spa_unit_test spa "--coverage")
-endif()
-
-install(TARGETS spa DESTINATION lib)
 
 
 add_executable(spa_unit_test ${TEST_SOURCES})
@@ -99,8 +93,6 @@ target_compile_options(spa_unit_test
     ${flags}
   )
   
-# really only needed for debug coverage
-
 target_link_libraries(spa_unit_test spa)
 
 # For interest sake, print includes
@@ -111,3 +103,11 @@ endforeach()
 
 #set(CMAKE_INSTALL_RPATH "${ORIGIN}")
 #set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
+# really only needed for debug coverage
+if(MY_PROFILING)
+    target_link_libraries(spa "--coverage")
+    target_link_libraries(spa_unit_test spa "--coverage")
+endif()
+
+install(TARGETS spa DESTINATION lib)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ plans by release.
 # Dependencies
 
 This library requires the user to have a working C++11 compiler. At present,
-and by design, no external dependencies (e.g. boost) are required.
+and by design, no external dependencies (e.g. boost) are required. It uses
+and includes the header-only `CUTE` unit testing framework created by 
+Peter Sommerlad.
 
 # Build And Test
 

--- a/build/BUILD.md
+++ b/build/BUILD.md
@@ -28,8 +28,8 @@ make all
 
 ### Test Coverage
 
-Test coverage reporting requires `govr`. To generate and visualize test coverage
-follow the example:
+Test coverage reporting requires `govr` is installed. To generate and visualize test 
+coverage by hand follow this example:
 
 ```bash
 cd build/
@@ -43,5 +43,13 @@ make
 
 # Use gcovr
 gcovr -r .. --html-details coverage.html
+firefox file://$(pwd)/coverage.html
+```
+
+Alternatively the `generate_coverage.sh` script can be used, which excludes
+the test code and CUTE headers from the coverage report.
+```bash
+cd build/
+bash ../extras/generate_coverage.sh ./
 firefox file://$(pwd)/coverage.html
 ```

--- a/build/BUILD.md
+++ b/build/BUILD.md
@@ -25,3 +25,23 @@ make all
 # Assumes you are in the build/ directory already
 ./spa_unit_test
 ```
+
+### Test Coverage
+
+Test coverage reporting requires `govr`. To generate and visualize test coverage
+follow the example:
+
+```bash
+cd build/
+cmake -D MY_PROFILING=ON ..
+
+# Build and run
+make
+# The compile generates .gcno files...
+# ...now run the test executable.
+./spa_unit_test
+
+# Use gcovr
+gcovr -r .. --html-details coverage.html
+firefox file://$(pwd)/coverage.html
+```

--- a/extra/generate_coverage.sh
+++ b/extra/generate_coverage.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#--------------------------------------------------------------------
+#
+# @brief Rerun CMake to enable code coverage, rebuild and run the test
+#  executable, and generate a HTML file of the code coverage using
+#  gcovr.
+#
+# bash generate_coverage.sh <build_dir>
+#
+#
+# @history 2025-03-27 dks : Initial coding
+#
+#--------------------------------------------------------------------
+#
+
+p_usage="$0 <build_dir>"
+if [ $# -ne 1 ]; then
+    echo "Error, expecting 1 command line argument, got $#"
+    echo "  usage: $p_usage"
+    exit 1
+fi
+
+p_odir=$(pwd)
+p_dir=$1
+if [ ! -d $p_dir ]; then
+    echo "Error, $p_dir is not a directory or an incomplete path."
+    echo "  Current directory: $p_odir"
+fi
+
+cd $p_dir
+
+echo "Removing old .gcno and .gcda files"
+rm $(find . -name "*.gcno" -o -name "*.gcda" | xargs)
+
+echo "Rebuilding make files"
+cmake -D MY_PROFILING=ON ..
+
+# Build and run
+echo "Rebuilding SPA and the test executable"
+make clean
+make
+
+# The compile generates .gcno files...
+# ...now run the test executable.
+echo "Running the test executable"
+./spa_unit_test
+
+# Use gcovr
+p_cov=coverage.html
+if [ -e $p_cov ]; then
+    rm $p_cov
+fi
+gcovr -r ..  -e "/.*\/test\/.*" \
+    -e "/.*\/inc\/GoodTimer.h" \
+    --html-details $p_cov
+p_covfile=$(pwd)'/'$p_cov
+
+echo "Generated coverage report $p_covfile"
+echo "To view, run the following command: firefox file://$p_covfile"
+
+#--------------------------------------------------------------------
+#
+exit 0


### PR DESCRIPTION
- Modified `CMakeLists.txt` to fix a bug preventing code coverage and profiling from working.
- Updated `BUILD.md` to describe how to perform code coverage generation
- Added `extras/generate_coverage.sh` to perform all the steps necessary to generate coverage of the SPA library without including the test code.